### PR TITLE
docs: add Linux desktop section, InnerTune, and fix Monochrome link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ A curated and up-to-date list of free and open-source alternatives to Spotify, Y
     - [Offline Music Players (Windows)](#offline-music-players-windows)
   - [macOS](#macos)
     - [Offline Music Players (macOS)](#offline-music-players-macos)
+  - [Linux](#linux)
+    - [Online Streaming Clients (Linux)](#online-streaming-clients-linux)
+    - [Offline Music Players (Linux)](#offline-music-players-linux)
 - [Web Applications](#web-applications)
 - [License](#license)
 
@@ -37,6 +40,7 @@ This repository lists free and open-source (FOSS) music applications that serve 
 - [BloomeeTunes](https://github.com/HemantKArya/BloomeeTunes)
 - [Cubic Music](https://github.com/cybruGhost/Cubic-Music)
 - [Gyawun Music](https://github.com/sheikhhaziq/gyawun_music)
+- [InnerTune](https://github.com/z-huang/InnerTune)
 - [Just-Listen](https://github.com/RLD-JL/Just-Listen)
 - [Kreate](https://github.com/knighthat/Kreate)
 - [M3-Play](https://github.com/JAY01-CYBER/M3-Play)
@@ -118,9 +122,27 @@ This repository lists free and open-source (FOSS) music applications that serve 
 
 ---
 
+### Linux
+
+#### Online Streaming Clients (Linux)
+
+- [muffon](https://github.com/staniel359/muffon)
+- [Nuclear](https://github.com/nukeop/nuclear)
+- [Spotube](https://github.com/KRTirtho/spotube)
+- [YTMDesktop](https://github.com/th-ch/youtube-music)
+
+#### Offline Music Players (Linux)
+
+- [Amberol](https://gitlab.gnome.org/World/amberol)
+- [Harmonoid](https://github.com/harmonoid/harmonoid)
+- [Supersonic](https://github.com/dweymouth/supersonic)
+- [Tauon Music Box](https://github.com/Taiko2k/TauonMusicBox)
+
+---
+
 # Web Applications
 
-- [Monochrome](https:monochrome.tf/)
+- [Monochrome](https://monochrome.tf/)
 - [Octave](https://music.octavestreaming.com/)
 - [Piped](https://piped.video/)
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A curated and up-to-date list of free and open-source alternatives to Spotify, Y
     - [Online Streaming Clients (Windows)](#online-streaming-clients-windows)
     - [Offline Music Players (Windows)](#offline-music-players-windows)
   - [macOS](#macos)
+    - [Online Streaming Clients (macOS)](#online-streaming-clients-macos)
     - [Offline Music Players (macOS)](#offline-music-players-macos)
   - [Linux](#linux)
     - [Online Streaming Clients (Linux)](#online-streaming-clients-linux)
@@ -115,6 +116,13 @@ This repository lists free and open-source (FOSS) music applications that serve 
 ---
 
 ### macOS
+
+#### Online Streaming Clients (macOS)
+
+- [muffon](https://github.com/staniel359/muffon)
+- [Nuclear](https://github.com/nukeop/nuclear)
+- [Spotube](https://github.com/KRTirtho/spotube)
+- [YTMDesktop](https://github.com/th-ch/youtube-music)
 
 #### Offline Music Players (macOS)
 


### PR DESCRIPTION
### Description

This PR introduces a few quality and completeness improvements to the curated list:
- **Fix broken URL**: Corrected the URI syntax for Monochrome (\https:monochrome.tf/\ -> \https://monochrome.tf/\).
- **Linux Section**: Added the missing Linux desktop category under Desktop Applications with popular open-source clients (Spotube, Nuclear, Amberol, Supersonic, Harmonoid, Tauon Music Box).
- **Android Clients**: Added [InnerTune](https://github.com/z-huang/InnerTune) to the Android streaming clients list.
- **Table of Contents**: Updated table of contents to include the new Linux subsection.