### PR TITLE
docs: add Sepotify to Android online streaming clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This repository lists free and open-source (FOSS) music applications that serve 
 - [retune](https://github.com/samvabya/retune)
 - [RiPlay](https://github.com/fast4x/RiPlay)
 - [Sautify](https://github.com/wambugu71/Sautify)
+- [Sepotify](https://github.com/RMNO21/Sepotify)
 - [Simple-Tube](https://github.com/samyak2403/Simple-Tube)
 - [SimpMusic](https://github.com/maxrave-dev/SimpMusic)
 - [SoundPod](https://github.com/arunnechully/SoundPod)


### PR DESCRIPTION
Adds [Sepotify](https://github.com/RMNO21/Sepotify) to the Android Online Streaming Clients list.

### About Sepotify
- Native Android music streaming client written in Kotlin & Jetpack Compose.
- Free, open-source Spotify-inspired UI backed by YouTube/InnerTube audio stream playback without ads.
- Features ExoPlayer / Media3 background audio playback, system media session, and Spotify metadata.